### PR TITLE
Add sorting and filtering to Catalogue

### DIFF
--- a/src/components/catalogue/Catalogue.tsx
+++ b/src/components/catalogue/Catalogue.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEvent, useState, useEffect } from "react";
+import { ChangeEvent, useState, useMemo } from "react";
 import { Search, RotateCcw } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import EditItemModal from "./EditItemModal";
@@ -14,61 +14,47 @@ interface CatalogueProps {
 }
 
 export default function Catalogue({ items: initialItems, slocs, ihs }: CatalogueProps) {
-  const [items, setItems] = useState(initialItems);
-
-  // Sync items when initialItems changes (e.g., after refresh)
-  useEffect(() => {
-    setItems(initialItems);
-  }, [initialItems]);
-
-  // Sort 
-  type SortOption = "name" | "quantity";
-  const [sortOption, setSortOption] = useState<SortOption>("name");
-  const [sortAsc, setSortAsc] = useState(true);
-
-  const sortItems = (option: SortOption, asc = sortAsc) => {
-    const sorted = [...items].sort((a, b) => {
-      if (option === "name") {
-        return asc 
-          ? a.itemDesc.localeCompare(b.itemDesc)
-          : b.itemDesc.localeCompare(a.itemDesc);
-      }
-      if (option === "quantity") {
-        return asc
-          ? a.itemQty - b.itemQty
-          : b.itemQty - a.itemQty
-      }
-      return 0;
-    });
-    setItems(sorted);
-  };
-
-  // Dropdown
-  const onSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const option = e.target.value as SortOption;
-    setSortOption(option);
-    sortItems(option);
-  };
-  
   // Filters
   const [searchString, setSearchString] = useState("");
   const [filterSloc, setFilterSloc] = useState<string>("");
   const [filterHolder, setFilterHolder] = useState<string>("");
 
-  const filteredItems = items.filter( (item) => {
-    const matchesSearch = 
+  const filteredItems = useMemo(() => {
+    return initialItems.filter((item) => {
+      const matchesSearch = 
         item.itemDesc.toLowerCase().includes(searchString.toLowerCase()) ||
         item.nuscSn.toLowerCase().includes(searchString.toLowerCase()) ||
         item.sloc.slocName.toLowerCase().includes(searchString.toLowerCase()) ||
         item.ih.ihName.toLowerCase().includes(searchString.toLowerCase()) ||
         (item.itemRemarks &&
           item.itemRemarks.toLowerCase().includes(searchString.toLowerCase()))
-    
-    const matchesSloc = !filterSloc || item.sloc.slocName === filterSloc;
-    const matchesHolder = !filterHolder || item.ih.ihName === filterHolder;
-    return matchesSearch && matchesSloc && matchesHolder; // Pass all filters 
-    } 
-  );
+      
+      const matchesSloc = !filterSloc || item.sloc.slocName === filterSloc;
+      const matchesHolder = !filterHolder || item.ih.ihName === filterHolder;
+      return matchesSearch && matchesSloc && matchesHolder;
+    });
+  }, [initialItems, searchString, filterSloc, filterHolder]);
+
+  // Sort state
+  type SortOption = "name" | "quantity";
+  const [sortOption, setSortOption] = useState<SortOption>("name");
+  const [sortAsc, setSortAsc] = useState(true);
+
+  const sortedFilteredItems = useMemo(() => {
+    return [...filteredItems].sort((a, b) => {
+      if (sortOption === "name") {
+        return sortAsc 
+          ? a.itemDesc.localeCompare(b.itemDesc)
+          : b.itemDesc.localeCompare(a.itemDesc);
+      }
+      if (sortOption === "quantity") {
+        return sortAsc
+          ? a.itemQty - b.itemQty
+          : b.itemQty - a.itemQty
+      }
+      return 0;
+    });
+  }, [filteredItems, sortOption, sortAsc]);
 
   const onInput = (ev: ChangeEvent<HTMLInputElement>) => {
     setSearchString(ev.target.value);
@@ -87,7 +73,6 @@ export default function Catalogue({ items: initialItems, slocs, ihs }: Catalogue
     setFilterHolder(defaultFilters.filterHolder);
     setSortOption(defaultFilters.sortOption);
     setSortAsc(defaultFilters.sortAsc);
-    sortItems(defaultFilters.sortOption, defaultFilters.sortAsc);
   };
 
   // Check if any filter is not in default state
@@ -103,7 +88,7 @@ export default function Catalogue({ items: initialItems, slocs, ihs }: Catalogue
       <div className="mb-8 flex items-center justify-between">
         <div>
           <h1 className="mb-2 text-4xl font-bold text-white">Catalogue</h1>
-          <p className="text-white/80">{filteredItems.length} ITEMS</p>
+          <p className="text-white/80">{sortedFilteredItems.length} ITEMS</p>
         </div>
         <EditItemModal slocs={slocs} ihs={ihs} mode="add" />
       </div>
@@ -160,7 +145,7 @@ export default function Catalogue({ items: initialItems, slocs, ihs }: Catalogue
 
       <select
            value={sortOption}
-           onChange={onSortChange}
+           onChange={(e) => setSortOption(e.target.value as SortOption)}
            className="h-9 rounded-md bg-white/20 px-3 text-white border border-white/20 focus:outline-none"
          >
            <option value="name" className="text-black">Sort by Item Name</option>
@@ -170,9 +155,7 @@ export default function Catalogue({ items: initialItems, slocs, ihs }: Catalogue
         {/*Asc/Desc Button*/}
          <button
            onClick={() => {
-             const nextAsc = !sortAsc;
-             setSortAsc(nextAsc);
-             sortItems(sortOption, nextAsc);
+             setSortAsc(!sortAsc);
            }}
            className="h-9 rounded-md bg-white/20 px-4 text-white hover:bg-white/30 transition-colors"
          >
@@ -182,14 +165,14 @@ export default function Catalogue({ items: initialItems, slocs, ihs }: Catalogue
       </div>
      
 
-      {filteredItems.length === 0 ? (
+      {sortedFilteredItems.length === 0 ? (
         <div className="py-16 text-center text-white/80">
           <p className="mb-2 text-xl">No items found</p>
           <p>Try adjusting your search criteria</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {filteredItems.map((item) => (
+          {sortedFilteredItems.map((item) => (
             <div
               key={item.itemId}
               className="flex flex-col rounded-lg bg-white p-6"


### PR DESCRIPTION
- Sort by item name and quantity with ascending/descending order (can see which items are running out)
- Filter by storage location and inventory holder (for logs team when stocktaking)
- Sort and filter functions work together with the already implemented search
- Update UI with dropdowns and toggle button (asc/desc) 
